### PR TITLE
Add manual redirect handling to prerenderRequest

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,8 @@ function prerenderRequest(request) {
   headersToSend.set('X-Prerender-Token', API_KEY);
 
   const prerenderRequest = new Request(prerenderUrl, {
-    headers: headersToSend
+    headers: headersToSend,
+    redirect: 'manual',
   });
 
   return fetch(prerenderRequest);


### PR DESCRIPTION
Fetch follows redirects by default. If prerender servers a redirect we want that to be returned to bots so we should define manual redirect mode - https://javascript.info/fetch-api#redirect